### PR TITLE
Quick hack to retrieve specific threads by specifying the thread URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 # slack-export related files
 files.slack.com
 *-slack_export/
+
+# Vim swap files
+.*.sw*

--- a/STEP-BY-STEP.md
+++ b/STEP-BY-STEP.md
@@ -73,7 +73,7 @@
 
 ## Obtain Token and Cookies
 
-1. In Firefox, open https://YOUR-SLACK-WORKSPACE.slack.com/customize.
+1. In a browser with developer tools active, open https://YOUR-SLACK-WORKSPACE.slack.com/customize.
 
 1. Sign in with SSO (if needed).
 


### PR DESCRIPTION
I had a thread that grew to enormous size (800+) and it became hard to analyze the timeline of some points so I did a quick hack to pull only the single thread and it was helpful. Feel free to close this PR if you think it won't be useful for others. I had to add an option to disable bootstrap, again a quick hack to workaround errors retrieving users and channels, but for retrieving specific threads, I think bootstrap is not needed so it is a good option to have.